### PR TITLE
ci: use GitHub App token for update-baseline workflow to trigger CI

### DIFF
--- a/.github/workflows/update-baseline.yml
+++ b/.github/workflows/update-baseline.yml
@@ -17,12 +17,18 @@ jobs:
       contents: write
       pull-requests: write
 
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -41,6 +47,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ steps.generate_token.outputs.token }}
           commit-message: "fix: update baseline data"
           title: "fix: update baseline data"
           branch: update-baseline-data


### PR DESCRIPTION
### What

Use GitHub App token instead of `GITHUB_TOKEN` in update-baseline workflow.

### Why

`GITHUB_TOKEN` doesn't trigger CI on created PRs.
This caused us to miss test failures in #53.