### PR TITLE
feat: warn about unnecessary `@supports` guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This rule reports the following cases:
 - CSS property values that aren't widely available or aren't enclosed in a `@supports` block (currently limited to identifiers only).
 - CSS functions that aren't widely available.
 - CSS pseudo-elements and pseudo-classes that aren't widely available.
+- Unnecessary `@supports` blocks when all checked features are already available at the configured baseline level.
 
 The data is sourced from [`web-features`](https://npmjs.com/package/web-features).
 
@@ -101,6 +102,24 @@ h1:has(+ h2) {
 /* device-posture is not widely available */
 @media (device-posture: folded) {
   a {
+    color: red;
+  }
+}
+```
+
+```css
+/* unnecessary @supports - display property and flex value are both widely available */
+@supports (display: flex) {
+  .container {
+    display: flex;
+  }
+}
+```
+
+```css
+/* unnecessary @supports - :hover selector is widely available */
+@supports selector(:hover) {
+  a:hover {
     color: red;
   }
 }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -481,7 +481,7 @@ const ruleFunction = (primary, secondaryOptions) => {
 
       supportsRules.push(supportsRule);
 
-      const unnecessaryGuards = [];
+      const redundantSupports = [];
 
       try {
         const ast = parse(atRule.params, {
@@ -531,7 +531,7 @@ const ruleFunction = (primary, secondaryOptions) => {
 
               const nodeStart = node.loc?.start?.offset || 0;
               const nodeEnd = node.loc?.end?.offset || 0;
-              const guardText = atRule.params.substring(nodeStart, nodeEnd);
+              const conditionText = atRule.params.substring(nodeStart, nodeEnd);
 
               // If the property is baseline, the @supports is unnecessary
               let isSupportsNecessary = !isPropertyBaselineCompliant;
@@ -575,8 +575,8 @@ const ruleFunction = (primary, secondaryOptions) => {
 
               // If all parts are baseline, the @supports is unnecessary
               if (!isSupportsNecessary) {
-                unnecessaryGuards.push({
-                  guardText,
+                redundantSupports.push({
+                  conditionText,
                   startIndex: nodeStart,
                   endIndex: nodeEnd,
                 });
@@ -589,7 +589,7 @@ const ruleFunction = (primary, secondaryOptions) => {
             ) {
               const nodeStart = node.loc?.start?.offset || 0;
               const nodeEnd = node.loc?.end?.offset || 0;
-              const guardText = atRule.params.substring(nodeStart, nodeEnd);
+              const conditionText = atRule.params.substring(nodeStart, nodeEnd);
 
               let isSupportsNecessary = false;
 
@@ -610,8 +610,8 @@ const ruleFunction = (primary, secondaryOptions) => {
               }
 
               if (!isSupportsNecessary) {
-                unnecessaryGuards.push({
-                  guardText,
+                redundantSupports.push({
+                  conditionText,
                   startIndex: nodeStart,
                   endIndex: nodeEnd,
                 });
@@ -630,18 +630,18 @@ const ruleFunction = (primary, secondaryOptions) => {
           },
         });
 
-        if (unnecessaryGuards.length > 0) {
+        if (redundantSupports.length > 0) {
           const atRuleParamOffset = atRuleParamIndex(atRule);
 
-          unnecessaryGuards.forEach((guard) => {
+          redundantSupports.forEach((condition) => {
             report({
               ruleName,
               message: messages.unnecessarySupports,
-              messageArgs: [guard.guardText, baselineAvailability.availability],
+              messageArgs: [condition.conditionText, baselineAvailability.availability],
               result,
               node: atRule,
-              index: atRuleParamOffset + guard.startIndex,
-              endIndex: atRuleParamOffset + guard.endIndex,
+              index: atRuleParamOffset + condition.startIndex,
+              endIndex: atRuleParamOffset + condition.endIndex,
             });
           });
         }

--- a/src/lib/index.test.js
+++ b/src/lib/index.test.js
@@ -285,9 +285,9 @@ testRule({
       `,
       warnings: [
         {
-          message: messages.unnecessarySupportsProperty("color", "widely"),
+          message: messages.unnecessarySupports("(color: red)", "widely"),
           line: 3,
-          column: 1,
+          column: 11,
           endLine: 3,
           endColumn: 23,
         },
@@ -311,9 +311,9 @@ testRule({
       `,
       warnings: [
         {
-          message: messages.unnecessarySupportsProperty("color", "widely"),
+          message: messages.unnecessarySupports("(color: red)", "widely"),
           line: 1,
-          column: 1,
+          column: 11,
           endLine: 1,
           endColumn: 23,
         },
@@ -604,42 +604,70 @@ testRule({
       description:
         "negated @supports guards are not checked for unnecessary guards",
     },
+    {
+      code: "@supports (transform: rotate(45deg) unknownFunc()) { a { color: red; } }",
+      description:
+        "Multiple functions where one is not baseline - should NOT warn about unnecessary @supports",
+    },
   ],
 
   reject: [
     {
       code: "@supports (color: red) { a { color: red; } }",
-      message: messages.unnecessarySupportsProperty("color", "widely"),
+      message: messages.unnecessarySupports("(color: red)", "widely"),
       line: 1,
-      column: 1,
+      column: 11,
       endLine: 1,
       endColumn: 23,
     },
     {
       code: "@supports (display: flex) { a { display: flex; } }",
-      message: messages.unnecessarySupportsPropertyValue(
-        "display",
-        "flex",
-        "widely",
-      ),
+      message: messages.unnecessarySupports("(display: flex)", "widely"),
       line: 1,
-      column: 1,
+      column: 11,
       endLine: 1,
       endColumn: 26,
     },
     {
       code: "@supports (width: calc(1px + 2px)) { a { width: calc(1px + 2px); } }",
-      message: messages.unnecessarySupportsType("calc", "widely"),
+      message: messages.unnecessarySupports(
+        "(width: calc(1px + 2px))",
+        "widely",
+      ),
       line: 1,
-      column: 1,
+      column: 11,
       endLine: 1,
       endColumn: 35,
     },
     {
-      code: "@supports selector(:hover) { a:hover { color: red; } }",
-      message: messages.unnecessarySupportsSelector("hover", "widely"),
+      code: "@supports (transform: rotate(45deg) scale(2)) { a { color: red; } }",
+      description: "Multiple functions that are all baseline",
+      message: messages.unnecessarySupports(
+        "(transform: rotate(45deg) scale(2))",
+        "widely",
+      ),
       line: 1,
-      column: 1,
+      column: 11,
+      endLine: 1,
+      endColumn: 46,
+    },
+    {
+      code: "@supports (background: linear-gradient(red, blue) url('image.png')) { a { color: red; } }",
+      description: "Multiple values with mixed types (function and url)",
+      message: messages.unnecessarySupports(
+        "(background: linear-gradient(red, blue) url('image.png'))",
+        "widely",
+      ),
+      line: 1,
+      column: 11,
+      endLine: 1,
+      endColumn: 68,
+    },
+    {
+      code: "@supports selector(:hover) { a:hover { color: red; } }",
+      message: messages.unnecessarySupports("selector(:hover)", "widely"),
+      line: 1,
+      column: 11,
       endLine: 1,
       endColumn: 27,
     },
@@ -651,16 +679,16 @@ testRule({
       `,
       warnings: [
         {
-          message: messages.unnecessarySupportsProperty("padding", "widely"),
+          message: messages.unnecessarySupports("(padding: 10px)", "widely"),
           line: 1,
-          column: 1,
+          column: 11,
           endLine: 1,
-          endColumn: 45,
+          endColumn: 26,
         },
         {
-          message: messages.unnecessarySupportsProperty("margin", "widely"),
+          message: messages.unnecessarySupports("(margin: 10px)", "widely"),
           line: 1,
-          column: 1,
+          column: 31,
           endLine: 1,
           endColumn: 45,
         },
@@ -684,9 +712,9 @@ testRule({
   reject: [
     {
       code: "@supports (backdrop-filter: auto) { a { backdrop-filter: auto; } }",
-      message: messages.unnecessarySupportsProperty("backdrop-filter", "newly"),
+      message: messages.unnecessarySupports("(backdrop-filter: auto)", "newly"),
       line: 1,
-      column: 1,
+      column: 11,
       endLine: 1,
       endColumn: 34,
     },

--- a/src/lib/index.test.js
+++ b/src/lib/index.test.js
@@ -283,11 +283,22 @@ testRule({
           }
         }
       `,
-      message: messages.notBaselineSelector("has", "widely"),
-      line: 4,
-      column: 5,
-      endLine: 4,
-      endColumn: 9,
+      warnings: [
+        {
+          message: messages.unnecessarySupportsProperty("color", "widely"),
+          line: 3,
+          column: 1,
+          endLine: 3,
+          endColumn: 23,
+        },
+        {
+          message: messages.notBaselineSelector("has", "widely"),
+          line: 4,
+          column: 5,
+          endLine: 4,
+          endColumn: 9,
+        },
+      ],
     },
     {
       code: stripIndent`
@@ -298,11 +309,22 @@ testRule({
           }
         }
       `,
-      message: messages.notBaselineProperty("accent-color", "widely"),
-      line: 4,
-      column: 5,
-      endLine: 4,
-      endColumn: 17,
+      warnings: [
+        {
+          message: messages.unnecessarySupportsProperty("color", "widely"),
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 23,
+        },
+        {
+          message: messages.notBaselineProperty("accent-color", "widely"),
+          line: 4,
+          column: 5,
+          endLine: 4,
+          endColumn: 17,
+        },
+      ],
     },
   ],
 });
@@ -561,6 +583,112 @@ testRule({
       column: 12,
       endLine: 1,
       endColumn: 15,
+    },
+  ],
+});
+
+// Tests for unnecessary @supports guards
+testRule({
+  plugins: [plugin],
+  ruleName,
+  config: true,
+
+  accept: [
+    {
+      code: "@supports (accent-color: auto) { a { accent-color: auto; } }",
+      description:
+        "accent-color is not widely available, so @supports guard is necessary",
+    },
+    {
+      code: "@supports not (color: red) { a { color: red; } }",
+      description:
+        "negated @supports guards are not checked for unnecessary guards",
+    },
+  ],
+
+  reject: [
+    {
+      code: "@supports (color: red) { a { color: red; } }",
+      message: messages.unnecessarySupportsProperty("color", "widely"),
+      line: 1,
+      column: 1,
+      endLine: 1,
+      endColumn: 23,
+    },
+    {
+      code: "@supports (display: flex) { a { display: flex; } }",
+      message: messages.unnecessarySupportsPropertyValue(
+        "display",
+        "flex",
+        "widely",
+      ),
+      line: 1,
+      column: 1,
+      endLine: 1,
+      endColumn: 26,
+    },
+    {
+      code: "@supports (width: calc(1px + 2px)) { a { width: calc(1px + 2px); } }",
+      message: messages.unnecessarySupportsType("calc", "widely"),
+      line: 1,
+      column: 1,
+      endLine: 1,
+      endColumn: 35,
+    },
+    {
+      code: "@supports selector(:hover) { a:hover { color: red; } }",
+      message: messages.unnecessarySupportsSelector("hover", "widely"),
+      line: 1,
+      column: 1,
+      endLine: 1,
+      endColumn: 27,
+    },
+    {
+      code: stripIndent`
+        @supports (padding: 10px) and (margin: 10px) {
+          a { padding: 10px; margin: 10px; }
+        }
+      `,
+      warnings: [
+        {
+          message: messages.unnecessarySupportsProperty("padding", "widely"),
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 45,
+        },
+        {
+          message: messages.unnecessarySupportsProperty("margin", "widely"),
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 45,
+        },
+      ],
+    },
+  ],
+});
+
+// Tests for unnecessary @supports guards with "newly" availability
+testRule({
+  plugins: [plugin],
+  ruleName,
+  config: [true, { available: "newly" }],
+
+  accept: [
+    {
+      code: "@supports (accent-color: auto) { a { accent-color: auto; } }",
+    },
+  ],
+
+  reject: [
+    {
+      code: "@supports (backdrop-filter: auto) { a { backdrop-filter: auto; } }",
+      message: messages.unnecessarySupportsProperty("backdrop-filter", "newly"),
+      line: 1,
+      column: 1,
+      endLine: 1,
+      endColumn: 34,
     },
   ],
 });


### PR DESCRIPTION
## What 

Closes #54 

Reports warnings when `@supports` blocks are no longer needed because all features they check have become available at the configured baseline level.

```css
/* Warning: @supports (color: red) is unnecessary */
@supports (color: red) {
  a { color: red; }
}

/* No warning: accent-color is not widely available */
@supports (accent-color: auto) {
  a { accent-color: auto; }
}
```

### How it works

- Checks if all parts (property, values, functions, selectors) meet baseline requirements
- Only reports as unnecessary when ALL features are baseline-compliant
- Reports each unnecessary condition with precise location
