### PR TITLE
chore: remove unnecessary lifecycle scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,6 @@
     "format": "prettier --write .",
     "validate": "npm run lint && npm run test",
     "build:baseline": "node tools/generate-baseline.js",
-    "prepare": "npm run build",
-    "prepublishOnly": "npm run lint && npm test",
     "release": "semantic-release"
   },
   "dependencies": {


### PR DESCRIPTION
pnpm displays warnings for lifecycle scripts, which is annoying for users.
These scripts are redundant since our CI/CD pipeline already handles build and validation.

Ref: https://socket.dev/blog/pnpm-10-0-0-blocks-lifecycle-scripts-by-default