### PR TITLE
chore: use NPM_TOKEN with provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,4 +44,5 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm run release


### PR DESCRIPTION
`@semantic-release/npm` v12 requires `NPM_TOKEN` for now.
See: https://github.com/semantic-release/npm/issues/958