### PR TITLE
fix(ci): drop npm install -g npm@latest to avoid Node 22.22.2 regression

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -20,10 +20,6 @@ runs:
         node-version: ${{ inputs.node-version }}
         package-manager-cache: false
 
-    - name: Update npm to latest (required for Trusted Publishing)
-      run: npm install -g npm@latest
-      shell: bash
-
     - name: Install dependencies
       run: pnpm install
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,8 @@ jobs:
 
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Update npm for OIDC support
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
## Summary
- CI was failing due to a regression in the Node 22.22.2 toolcache ([actions/runner-images#13883](https://github.com/actions/runner-images/issues/13883)): the bundled npm 10.9.7 is missing `promise-retry`, so `npm install -g npm@latest` fails with `Cannot find module 'promise-retry'`.
- Removed `npm install -g npm@latest` from the shared setup action — CI lint/test jobs run via pnpm and never needed it.
- Bumped `release.yml` from Node 22 to Node 24 and dropped the manual npm upgrade. Node 24 ships with npm 11.x (>= 11.5.1), which already satisfies the trusted publishing requirement, so the brittle self-upgrade step is no longer necessary.

## Failure being fixed
[Failing run](https://github.com/ryo-manba/stylelint-plugin-use-baseline/actions/runs/24920043868/job/72979688154):
```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - .../@npmcli/arborist/lib/arborist/rebuild.js
```

## Test plan
- [x] CI (Lint, Test 20/22/24) passes
- [ ] Verify the publish job runs successfully on Node 24 at the next release-please release

🤖 Generated with [Claude Code](https://claude.com/claude-code)