### PR TITLE
chore: bump pnpm to v11.1.1 and tighten supply chain config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-package-lock = false
-minimum-release-age = 1440

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/ryo-manba/stylelint-plugin-use-baseline/issues"
   },
-  "packageManager": "pnpm@10.18.2+sha512.9fb969fa749b3ade6035e0f109f0b8a60b5d08a1a87fdf72e337da90dcc93336e2280ca4e44f2358a649b83c17959e9993e777c2080879f3801e6f0d999ad3dd",
+  "packageManager": "pnpm@11.1.1+sha512.d1fdf5f73c617b64fa1a56a81c3c8dfe0e966e33a6010aa256b517ae77be21d93e05affc0de1a83b0e4f29d569f68b446ae8f068cd7247c0bb3df0fb4d7bdf9a",
   "publishConfig": {
     "provenance": true,
     "access": "public"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  unrs-resolver: true
+minimumReleaseAge: 1440 # 1 day in minutes
+trustPolicy: no-downgrade
+trustPolicyIgnoreAfter: 10080 # 1 week in minutes


### PR DESCRIPTION
## Summary

- Bump `packageManager` to `pnpm@11.1.1` (was `10.18.2`)
- Replace `.npmrc` with `pnpm-workspace.yaml` since pnpm v11 only reads auth/registry settings from `.npmrc`
- Migrate to the new `allowBuilds` map (replaces the removed `onlyBuiltDependencies`/`neverBuiltDependencies` family)
- Enable `trustPolicy: no-downgrade` as a defense-in-depth measure against supply-chain trust-evidence downgrades, scoped with `trustPolicyIgnoreAfter: 10080` (1 week) so the check focuses on fresh releases and doesn't block long-published legacy packages without provenance
- Keep `minimumReleaseAge: 1440` explicit (matches v11 default but written for clarity)

## Why pnpm v11

Highlights relevant here ([full release notes](https://github.com/pnpm/pnpm/releases/tag/v11.0.0)):

- Supply-chain defaults are now on: `minimumReleaseAge`, `blockExoticSubdeps`, `strictDepBuilds`
- `.npmrc` is auth/registry only — other settings must live in `pnpm-workspace.yaml`
- Build-script allowlist consolidated into `allowBuilds`
- Faster install (SQLite store index, undici, etc.)

## Final config

```yaml
# pnpm-workspace.yaml
allowBuilds:
  unrs-resolver: true            # native resolver pulled in by jest@30 → jest-resolve
minimumReleaseAge: 1440           # 1 day in minutes
trustPolicy: no-downgrade
trustPolicyIgnoreAfter: 10080     # 1 week in minutes
```

## Test plan

- [x] `pnpm install` on a clean `node_modules`/lockfile
- [x] `pnpm test` (125/125 passes)
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)